### PR TITLE
feat: fix home routing and unify tab-based navigation

### DIFF
--- a/frontend/sustenta_bag_application/lib/AppShell.dart
+++ b/frontend/sustenta_bag_application/lib/AppShell.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'components/navbar.dart';
+import 'screens/homeScreen.dart';
+import 'screens/history/HistoryScreen.dart';
+import 'screens/bag/BagScreen.dart';
+import 'screens/profileScreen.dart';
+
+class AppShell extends StatefulWidget {
+  const AppShell({Key? key}) : super(key: key);
+
+  @override
+  _AppShellState createState() => _AppShellState();
+}
+
+class _AppShellState extends State<AppShell> {
+  int currentIndex = 0;
+
+  final pages = const [
+    DashboardScreen(),
+    HistoryScreen(),
+    BagScreen(),
+    ProfileScreen(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: IndexedStack(
+        index: currentIndex,
+        children: pages,
+      ),
+      bottomNavigationBar: BottomNavBar(
+        currentIndex: currentIndex,
+        onItemSelected: (i) => setState(() => currentIndex = i),
+      ),
+    );
+  }
+}

--- a/frontend/sustenta_bag_application/lib/main.dart
+++ b/frontend/sustenta_bag_application/lib/main.dart
@@ -1,17 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:sustenta_bag_application/screens/FavoritesScreen.dart';
-import 'package:sustenta_bag_application/screens/Register/RegisterStep1.dart';
-import 'package:sustenta_bag_application/screens/Register/RegisterStep2.dart';
-import 'package:sustenta_bag_application/screens/Register/RegisterStep3.dart';
-import 'package:sustenta_bag_application/screens/profileScreen.dart';
+import 'package:sustenta_bag_application/AppShell.dart' show AppShell;
 import 'screens/IntroScreen.dart';
 import 'screens/LoginScreen.dart';
-import 'screens/homeScreen.dart';
-import 'screens/bag/BagScreen.dart';
+import 'screens/Register/RegisterStep1.dart';
+import 'screens/Register/RegisterStep2.dart';
+import 'screens/Register/RegisterStep3.dart';
 import 'screens/bag/DeliveryOptionsScreen.dart';
 import 'screens/bag/ReviewOrderScreen.dart';
-import 'screens/bag/PaymentScreen.dart'; 
-import 'screens/history/HistoryScreen.dart';
+import 'screens/bag/PaymentScreen.dart';
+import 'screens/FavoritesScreen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -19,70 +16,44 @@ void main() {
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'SustentaBag',
       initialRoute: '/',
+      routes: {
+        '/': (_) => const IntroScreen(),
+        '/login': (_) => const LoginScreen(),
+        '/home': (_) => const AppShell(),
+        '/app': (_) => const AppShell(),
+        '/register1': (_) => RegisterStep1(),
+        '/register2': (_) => RegisterStep2(),
+        '/register3': (_) => RegisterStep3(),
+        '/bag/payment': (_) => const PaymentScreen(),
+        '/favorites': (_) => FavoritesScreen(),
+      },
       onGenerateRoute: (settings) {
+        final args = (settings.arguments ?? {}) as Map<String, dynamic>;
         switch (settings.name) {
-          case '/':
-            return MaterialPageRoute(builder: (context) => const IntroScreen());
-
-          case '/login':
-            return MaterialPageRoute(builder: (context) => const LoginScreen());
-
-          case '/home':
-            return MaterialPageRoute(
-                builder: (context) => const DashboardScreen());
-
-          case '/bag':
-            return MaterialPageRoute(builder: (context) => const BagScreen());
-
           case '/bag/deliveryOptions':
-            final args = settings.arguments as Map<String, dynamic>? ?? {};
             return MaterialPageRoute(
-              builder: (context) => DeliveryOptionScreen(
+              builder: (_) => DeliveryOptionScreen(
                 hasDelivery: args['hasDelivery'] ?? false,
                 userAddress: args['userAddress'] ?? '',
                 storeAddress: args['storeAddress'] ?? '',
-                subtotal: args['subtotal'] ?? 0.0, 
+                subtotal: args['subtotal'] ?? 0.0,
               ),
             );
-
           case '/bag/reviewOrder':
-            final args = settings.arguments as Map<String, dynamic>? ?? {};
             return MaterialPageRoute(
-              builder: (context) => ReviewOrderScreen(
+              builder: (_) => ReviewOrderScreen(
                 subtotal: args['subtotal'] ?? 0.0,
                 deliveryFee: args['deliveryFee'] ?? 0.0,
               ),
             );
-          case '/bag/payment':
-            return MaterialPageRoute(
-                builder: (context) => const PaymentScreen());
-          case '/history':
-            return MaterialPageRoute(
-                builder: (context) => const HistoryScreen());
-          case '/register1':
-            return MaterialPageRoute(builder: (context) => RegisterStep1());
-
-          case '/register2':
-            return MaterialPageRoute(builder: (context) => RegisterStep2());
-
-          case '/register3':
-            return MaterialPageRoute(builder: (context) => RegisterStep3());
-
-          case '/profile':
-            return MaterialPageRoute(builder: (context) => ProfileScreen());
-
-          case '/favorites':
-            return MaterialPageRoute(builder: (context) => FavoritesScreen());
-
           default:
-            return MaterialPageRoute(builder: (context) => const IntroScreen());
+            return null;
         }
       },
     );

--- a/frontend/sustenta_bag_application/lib/screens/bag/BagScreen.dart
+++ b/frontend/sustenta_bag_application/lib/screens/bag/BagScreen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:sustenta_bag_application/components/navbar.dart';
 
 class BagScreen extends StatefulWidget {
   const BagScreen({super.key});
@@ -34,10 +33,9 @@ class _BagScreenState extends State<BagScreen> {
         title: const Text('Sacolas'),
         centerTitle: true,
         backgroundColor: Colors.white,
-        automaticallyImplyLeading: false, 
+        automaticallyImplyLeading: false,
       ),
-      backgroundColor:
-          const Color(0xFFFFFFFF), 
+      backgroundColor: const Color(0xFFFFFFFF),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
@@ -137,25 +135,6 @@ class _BagScreenState extends State<BagScreen> {
             ),
           ],
         ),
-      ),
-      bottomNavigationBar: BottomNavBar(
-        currentIndex: 2,
-        onItemSelected: (index) {
-          switch (index) {
-            case 0:
-              Navigator.pushNamed(context, '/home');
-              break;
-            case 1:
-              Navigator.pushNamed(context, '/history');
-              break;
-            case 2:
-              Navigator.pushNamed(context, '/bag');
-              break;
-            case 3:
-              Navigator.pushNamed(context, '/profile');
-              break;
-          }
-        },
       ),
     );
   }

--- a/frontend/sustenta_bag_application/lib/screens/history/HistoryScreen.dart
+++ b/frontend/sustenta_bag_application/lib/screens/history/HistoryScreen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:sustenta_bag_application/components/navbar.dart';
 
 class HistoryScreen extends StatelessWidget {
   const HistoryScreen({super.key});
@@ -24,16 +23,14 @@ class HistoryScreen extends StatelessWidget {
         title: const Text('Status do Pedido'),
         centerTitle: true,
         backgroundColor: Colors.white,
-        automaticallyImplyLeading: false, 
+        automaticallyImplyLeading: false,
       ),
-      backgroundColor:
-          const Color(0xFFFFFFFF),
+      backgroundColor: const Color(0xFFFFFFFF),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // STATUS ATUAL
             Container(
               padding: const EdgeInsets.all(12),
               decoration: BoxDecoration(
@@ -62,7 +59,6 @@ class HistoryScreen extends StatelessWidget {
             ),
             const SizedBox(height: 24),
 
-            // LISTA DINÂMICA
             ...orderHistory.map((order) => Padding(
                   padding: const EdgeInsets.only(bottom: 16),
                   child: _buildHistoryItem(
@@ -73,25 +69,6 @@ class HistoryScreen extends StatelessWidget {
                 )),
           ],
         ),
-      ),
-      bottomNavigationBar: BottomNavBar(
-        currentIndex: 1, 
-        onItemSelected: (index) {
-          switch (index) {
-            case 0:
-              Navigator.pushNamed(context, '/home');
-              break;
-            case 1:
-              Navigator.pushNamed(context, '/history');
-              break;
-            case 2:
-              Navigator.pushNamed(context, '/bag');
-              break;
-            case 3:
-              Navigator.pushNamed(context, '/profile');
-              break;
-          }
-        },
       ),
     );
   }

--- a/frontend/sustenta_bag_application/lib/screens/homeScreen.dart
+++ b/frontend/sustenta_bag_application/lib/screens/homeScreen.dart
@@ -1,21 +1,19 @@
 import 'package:flutter/material.dart';
-import '../components/navbar.dart';
 import '../components/bagCard.dart';
 
 class DashboardScreen extends StatefulWidget {
-  const DashboardScreen({super.key});
+  const DashboardScreen({Key? key}) : super(key: key);
 
   @override
-  _DashboardScreenState createState() => _DashboardScreenState();
+  State<DashboardScreen> createState() => _DashboardScreenState();
 }
 
 class _DashboardScreenState extends State<DashboardScreen> {
   String selectedCategory = 'Ver tudo';
   bool showBanner = true;
-  bool categorySelected = true;
 
   final List<Map<String, dynamic>> bags = [
-    {
+     {
       'id': '1',
       'imagePath': 'assets/bag.png',
       'description': 'Doces irresistíveis para adoçar seu dia!',
@@ -90,10 +88,8 @@ class _DashboardScreenState extends State<DashboardScreen> {
   ];
 
   List<Map<String, dynamic>> get filteredBags {
-    if (selectedCategory == 'Ver tudo') {
-      return bags;
-    }
-    return bags.where((bag) => bag['category'] == selectedCategory).toList();
+    if (selectedCategory == 'Ver tudo') return bags;
+    return bags.where((b) => b['category'] == selectedCategory).toList();
   }
 
   @override
@@ -101,192 +97,152 @@ class _DashboardScreenState extends State<DashboardScreen> {
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
-        elevation: 0,
+        title: const Text('Início', style: TextStyle(color: Colors.black)),
         backgroundColor: Colors.white,
+        elevation: 0,
         actions: [
           IconButton(
-            icon: const Icon(Icons.notifications_none),
+            icon: const Icon(Icons.notifications_none, color: Colors.black),
             onPressed: () {},
           ),
         ],
       ),
-      body: ScrollbarTheme(
-        data: ScrollbarThemeData(
-          thumbColor: MaterialStateProperty.all(Colors.black87),
-          thickness: MaterialStateProperty.all(4),
-          radius: const Radius.circular(8),
-        ),
-        child: Scrollbar(
-          thumbVisibility: true,
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.only(left: 16, right: 16, bottom: 8),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (showBanner)
-                  Stack(
-                    children: [
-                      Container(
-                        padding: const EdgeInsets.all(16.0),
-                        decoration: BoxDecoration(
-                          color: Colors.amber[100],
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                        child: Row(
-                          children: [
-                            Image.asset('assets/foods.png', width: 80),
-                            const SizedBox(width: 10),
-                            const Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    'Veja sacolas perto de você',
-                                    style:
-                                        TextStyle(fontWeight: FontWeight.bold),
-                                  ),
-                                  SizedBox(height: 5),
-                                  ElevatedButton(
-                                    onPressed: null,
-                                    child: Text('Ver'),
-                                  ),
-                                ],
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (showBanner)
+              Stack(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: Colors.amber[100],
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Row(
+                      children: [
+                        Image.asset('assets/foods.png', width: 80),
+                        const SizedBox(width: 10),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              const Text(
+                                'Veja sacolas perto de você',
+                                style: TextStyle(
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 16,
+                                ),
                               ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      Positioned(
-                        right: 8,
-                        top: 8,
-                        child: GestureDetector(
-                          onTap: () {
-                            setState(() {
-                              showBanner = false;
-                            });
-                          },
-                          child: Container(
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: Colors.black.withOpacity(0.2),
-                            ),
-                            padding: const EdgeInsets.all(4),
-                            child: const Icon(
-                              Icons.close,
-                              color: Colors.white,
-                              size: 18,
-                            ),
+                              const SizedBox(height: 8),
+                              ElevatedButton(
+                                onPressed: () {
+                                  // ação futura
+                                },
+                                child: const Text('Ver'),
+                              ),
+                            ],
                           ),
                         ),
-                      ),
-                    ],
-                  ),
-                const SizedBox(height: 20),
-                TextField(
-                  decoration: InputDecoration(
-                    hintText: 'Pesquisar',
-                    prefixIcon: Icon(Icons.search),
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(12),
-                      borderSide: BorderSide.none,
+                      ],
                     ),
-                    filled: true,
-                    fillColor: Colors.grey[200],
                   ),
-                ),
-                const SizedBox(height: 10),
-                const Text(
-                  'Categorias Populares',
-                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-                ),
-                const SizedBox(height: 10),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    _buildCategory('Salgados', Icons.fastfood),
-                    _buildCategory('Doces', Icons.cake),
-                    _buildCategory('Mistas', Icons.restaurant),
-                    _buildCategory('Ver tudo', Icons.more_horiz),
-                  ],
-                ),
-                const SizedBox(height: 10),
-                if (categorySelected) ...[
-                  const Text(
-                    'Sacolas Disponíveis',
-                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-                  ),
-                  const SizedBox(height: 10),
-                  GridView.count(
-                    crossAxisCount: 2,
-                    mainAxisSpacing: 10,
-                    crossAxisSpacing: 10,
-                    childAspectRatio: 0.6,
-                    shrinkWrap: true,
-                    physics: const NeverScrollableScrollPhysics(),
-                    children: filteredBags.map((bag) {
-                      return BagCard(
-                        id: bag['id'],
-                        imagePath: bag['imagePath'],
-                        description: bag['description'],
-                        title: bag['title'],
-                        price: bag['price'],
-                        category: bag['category'],
-                      );
-                    }).toList(),
+                  Positioned(
+                    right: 8,
+                    top: 8,
+                    child: GestureDetector(
+                      onTap: () => setState(() => showBanner = false),
+                      child: const CircleAvatar(
+                        radius: 12,
+                        backgroundColor: Colors.black38,
+                        child: Icon(Icons.close, color: Colors.white, size: 16),
+                      ),
+                    ),
                   ),
                 ],
+              ),
+            const SizedBox(height: 20),
+            TextField(
+              decoration: InputDecoration(
+                hintText: 'Pesquisar',
+                prefixIcon: const Icon(Icons.search),
+                filled: true,
+                fillColor: Colors.grey[200],
+                contentPadding: const EdgeInsets.symmetric(vertical: 0),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: BorderSide.none,
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            const Text(
+              'Categorias Populares',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 10),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                _buildCategory('Salgados', Icons.fastfood),
+                _buildCategory('Doces', Icons.cake),
+                _buildCategory('Mistas', Icons.restaurant),
+                _buildCategory('Ver tudo', Icons.more_horiz),
               ],
             ),
-          ),
+            const SizedBox(height: 20),
+            const Text(
+              'Sacolas Disponíveis',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 10),
+            GridView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: filteredBags.length,
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 2,
+                childAspectRatio: 0.62,
+                crossAxisSpacing: 10,
+                mainAxisSpacing: 10,
+              ),
+              itemBuilder: (_, index) {
+                final bag = filteredBags[index];
+                return BagCard(
+                  id: bag['id'],
+                  imagePath: bag['imagePath'],
+                  description: bag['description'],
+                  title: bag['title'],
+                  price: bag['price'],
+                  category: bag['category'],
+                );
+              },
+            ),
+          ],
         ),
-      ),
-      bottomNavigationBar: BottomNavBar(
-        currentIndex: 0, 
-        onItemSelected: (index) {
-          switch (index) {
-            case 0:
-              Navigator.pushNamed(context, '/home');
-              break;
-            case 1:
-              Navigator.pushNamed(context, '/history');
-              break;
-            case 2:
-              Navigator.pushNamed(context, '/bag');
-              break;
-            case 3:
-              Navigator.pushNamed(context, '/profile');
-              break;
-          }
-        },
       ),
     );
   }
 
   Widget _buildCategory(String title, IconData icon) {
+    final isSelected = selectedCategory == title;
     return GestureDetector(
-      onTap: () {
-        setState(() {
-          selectedCategory = title;
-          categorySelected = true;
-        });
-      },
+      onTap: () => setState(() => selectedCategory = title),
       child: Column(
         children: [
           CircleAvatar(
-            backgroundColor:
-                selectedCategory == title ? Colors.orange : Colors.grey[200],
+            backgroundColor: isSelected ? Colors.orange : Colors.grey[200],
             child: Icon(
               icon,
-              color: selectedCategory == title ? Colors.white : Colors.black54,
+              color: isSelected ? Colors.white : Colors.black54,
             ),
           ),
           const SizedBox(height: 5),
           Text(
             title,
-            style: const TextStyle(
-              fontSize: 12,
-              fontWeight: FontWeight.normal,
-            ),
+            style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
           ),
         ],
       ),

--- a/frontend/sustenta_bag_application/lib/screens/profileScreen.dart
+++ b/frontend/sustenta_bag_application/lib/screens/profileScreen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:sustenta_bag_application/components/navbar.dart';
 
 class ProfileScreen extends StatelessWidget {
   const ProfileScreen({super.key});
@@ -13,13 +12,10 @@ class ProfileScreen extends StatelessWidget {
         backgroundColor: Colors.white,
         automaticallyImplyLeading: false,
       ),
-      backgroundColor:
-          const Color(0xFFFFFFFF), 
+      backgroundColor: const Color(0xFFFFFFFF),
       body: Center(
         child: ElevatedButton.icon(
-          onPressed: () {
-            Navigator.pushNamed(context, '/favorites');
-          },
+          onPressed: () => Navigator.pushNamed(context, '/favorites'),
           icon: const Icon(Icons.favorite, color: Color(0xFFE8514C)),
           label: const Text('Favoritos'),
           style: ElevatedButton.styleFrom(
@@ -32,24 +28,6 @@ class ProfileScreen extends StatelessWidget {
             ),
           ),
         ),
-      ),
-      bottomNavigationBar: BottomNavBar(
-        currentIndex: 3,
-        onItemSelected: (index) {
-          switch (index) {
-            case 0:
-              Navigator.pushNamed(context, '/home');
-              break;
-            case 1:
-              Navigator.pushNamed(context, '/history');
-              break;
-            case 2:
-              Navigator.pushNamed(context, '/bag');
-              break;
-            case 3:
-              break;
-          }
-        },
       ),
     );
   }


### PR DESCRIPTION
- Unify `/home` and `/app` routes to always load `AppShell`
- Remove static `/bag/deliveryOptions` and `/bag/reviewOrder` entries from `routes`
- Handle `deliveryOptions` and `reviewOrder` in `onGenerateRoute`, preserving arguments
- Ensure BottomNavBar remains visible via `IndexedStack` in `AppShell`